### PR TITLE
Adding ip_address to Transaction

### DIFF
--- a/transactions.go
+++ b/transactions.go
@@ -23,6 +23,7 @@ type Transaction struct {
 	Currency        string   `xml:"currency,omitempty"`
 	Status          string   `xml:"status,omitempty"`
 	Reference       string   `xml:"reference,omitempty"`
+	IpAddress       string   `xml:"ip_address,omitempty"`
 	Test            bool     `xml:"test,omitempty"`
 	Voidable        bool     `xml:"voidable,omitempty"`
 	Refundable      bool     `xml:"refundable,omitempty"`


### PR DESCRIPTION
Adding `ip_address` to transactions now that it's exposed
https://docs.recurly.com/api/transactions#create-transaction

cc: @cgerrior 

Test:
`transaction = r.GetTransaction("<uuid>")`
`fmt.Printf(transaction.IpAddress)`
