### PR TITLE
`Invoice` now has `closed_at`

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -23,6 +23,7 @@ type Invoice struct {
 	Currency string `xml:"currency,omitempty"`
 	CreatedAt *time.Time `xml:"created_at,omitempty"`
 	LineItems []LineItems `xml:"line_items,omitempty"`
+	ClosedAt *time.Time `xml:"closed_at,omitempty"`
 	//Transactions []Transaction `xml:"transactions,omitempty"`
 }
 


### PR DESCRIPTION
Adding `closed_at` to `Invoice` since it’s exposed publicly. 

cc: @cgerrior

```
if invoice, err := r.GetInvoice(invoice); err == nil{
fmt.Printf(invoice.CloseAt)
}
```
